### PR TITLE
Make nerdctl call generic, parameterize namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Vessel <img src="http://www.pngmart.com/files/12/Vessel-PNG-Transparent-Picture.png" width="40" height="40" alt=":vessel:" class="emoji" title=":vessel:"/>
 
 Vessel is the Go based utility that autodetects underlying Container Runtime in Kubernetes.
+
+## Containerd namespace
+
+Vessel scans every available namespaces from containerd.
+Current behavior conists of issuing a command to every namespace until one succeeds.

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Vessel is the Go based utility that autodetects underlying Container Runtime in 
 ## Containerd namespace
 
 Vessel scans every available namespaces from containerd.
-Current behavior conists of issuing a command to every namespace until one succeeds.
+Current behavior consists of issuing a command to every namespace until one succeeds.

--- a/cmd/vessel/main.go
+++ b/cmd/vessel/main.go
@@ -1,21 +1,22 @@
 package main
 
 import (
-	"github.com/deepfence/vessel"
-	"github.com/joho/godotenv"
-	"github.com/sirupsen/logrus"
 	"log"
 	"os"
+
+	"github.com/deepfence/vessel"
+	"github.com/deepfence/vessel/constants"
+	"github.com/joho/godotenv"
+	"github.com/sirupsen/logrus"
 )
 
 var activeRuntime string
-var sockPath string
 var containerRuntime string
 
 func init() {
 	var err error
 	// Auto-detect underlying container runtime
-	containerRuntime, sockPath, err = vessel.AutoDetectRuntime()
+	containerRuntime, err = vessel.AutoDetectRuntime()
 	if err != nil {
 		logrus.Error(err)
 		os.Exit(1)
@@ -42,7 +43,7 @@ func main() {
 	if activeRuntime != "" {
 		envVars := map[string]string{
 			"CONTAINER_RUNTIME": containerRuntime,
-			"CRI_ENDPOINT":      sockPath,
+			"CRI_ENDPOINT":      constants.SupportedRuntimes[containerRuntime],
 		}
 		setDotEnvVariable(envVars)
 	}

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -9,9 +9,12 @@ const (
 	CONTAINERD                = "containerd"
 	DOCKER                    = "docker"
 	CONTAINERD_SOCKET_ADDRESS = "/run/containerd/containerd.sock"
+	DOCKER_SOCKET_ADDRESS     = "/var/run/docker.sock"
+	CONTAINERD_SOCKET_IRI     = "unix://" + CONTAINERD_SOCKET_ADDRESS
+	DOCKER_SOCKET_IRI         = "unix://" + DOCKER_SOCKET_ADDRESS
 )
 
 var SupportedRuntimes = map[string]string{
-	"unix:///var/run/docker.sock":            DOCKER,
-	"unix:///run/containerd/containerd.sock": CONTAINERD,
+	DOCKER:     DOCKER_SOCKET_IRI,
+	CONTAINERD: CONTAINERD_SOCKET_IRI,
 }

--- a/containerd/types.go
+++ b/containerd/types.go
@@ -2,4 +2,5 @@ package containerd
 
 type Containerd struct {
 	socketPath string
+	namespaces []string
 }


### PR DESCRIPTION
This change aims at making containerd usage more robust:
- Change binary calls to `nerdctl` instead of `/usr/local/bin/nerdctl`
- Test all available namespace when issuing a `Save` command
- Rework some of the logic around sockets/runtimes
- Change `getContainerRuntime` behavior by allowing accessible runtimes that do not have containers running. If a runtime has containers running, it will have priority over those that do not have any.